### PR TITLE
Setup Aviationexam.DependencyUpdater for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directory: "src" # Location of package manifests
-    schedule:
-      interval: "daily"
-    groups:
-      microsoft:
-        patterns:
-          - Microsoft.*
-          - System.*
-      xunit:
-        patterns:
-          - xunit
-          - xunit.*
-
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/updater.yml
+++ b/.github/updater.yml
@@ -1,0 +1,25 @@
+# Configuration for Aviationexam.DependencyUpdater
+# See: https://github.com/aviationexam/Aviationexam.DependencyUpdater
+
+version: 2
+
+registries:
+  nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+    nuget-feed-version: V3
+
+updates:
+  - package-ecosystem: "nuget"
+    directory: "src"
+    targetFramework: net10.0
+    execute-restore: true
+    groups:
+      microsoft:
+        patterns:
+          - Microsoft.*
+          - System.*
+      xunit:
+        patterns:
+          - xunit
+          - xunit.*

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,0 +1,32 @@
+name: 'Updater: Dependency Updates'
+
+on:
+  schedule:
+    # Run every day at 8am UTC
+    - cron: '0 8 * * *'
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+# Required permissions for the action to work
+permissions:
+  contents: write      # Required to create branches and commits
+  pull-requests: write # Required to create pull requests
+  issues: write        # Required to create and apply labels to pull requests
+
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository with full history for rebasing
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Full clone required for git operations (rebase, fetch)
+
+      # Run the dependency updater using the action from this repository
+      - name: Update dependencies
+        uses: aviationexam/Aviationexam.DependencyUpdater@0.4.10
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR sets up the Aviationexam.DependencyUpdater to automate NuGet dependency updates, replacing Dependabot for NuGet packages while keeping it for GitHub Actions.

## Changes

- Created `.github/updater.yml` with configuration for NuGet dependency updates
  - Configured for `net10.0` target framework
  - Preserved existing grouping rules for Microsoft and xUnit packages
  - Added public NuGet registry configuration
- Updated `.github/dependabot.yml` to remove NuGet ecosystem (keeping only github-actions)
- Added `.github/workflows/dependency-updates.yml` workflow
  - Runs daily at 8am UTC
  - Can be manually triggered
  - Uses `aviationexam/Aviationexam.DependencyUpdater@0.4.10`

## Benefits

- More advanced NuGet dependency management
- Better support for multi-targeted projects
- Automated PR creation with proper grouping
- Maintains existing dependency update grouping strategy

## Documentation

See [Aviationexam.DependencyUpdater](https://github.com/aviationexam/Aviationexam.DependencyUpdater) for more information.