### PR TITLE
Bump xunit.v3.mtp-v2 from 3.2.0 to 3.2.1

### DIFF
--- a/src/DockerComposeBuilder.Tests/DockerComposeBuilder.Tests.csproj
+++ b/src/DockerComposeBuilder.Tests/DockerComposeBuilder.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.1.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.0.2" />
-    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates 1 packages:

- Update xunit.v3.mtp-v2 from 3.2.0 to 3.2.1
